### PR TITLE
feat: Add workflow_dispatch trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Enables manual release triggering from GitHub Actions UI when automated
releases don't trigger (e.g., when PR titles lack conventional commit prefixes).

Usage: Actions → Release Please → Run workflow → Select main → Run