### PR TITLE
fix: configure Git credentials for semantic-release-github-pullrequest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,17 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "lts/*"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
         run: npm install -D semantic-release @semantic-release/changelog semantic-release-github-pullrequest


### PR DESCRIPTION
The plugin was failing with "error NaN" when trying to create branches because Git credentials were not configured.

Changes:
- Use MY_RELEASE_PLEASE_TOKEN in checkout action to persist credentials
- Add Git configuration for user.name and user.email
- This allows the plugin to push release branches to GitHub

Error was: "Branch 'release-0.7.0' not created (error NaN)"

https://claude.ai/code/session_0131qaN8MeQ8noKjwrbbBTuU