### PR TITLE
fix: Add logger to all fuzz tests to prevent nil pointer dereference

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -22,8 +22,9 @@ func FuzzWithName(f *testing.F) {
 	f.Add("with\nnewline")
 	f.Add("特殊字符")
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, name string) {
-		srv, err := server.New(server.WithName(name))
+		srv, err := server.New(server.WithName(name), server.WithLogger(logger))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -46,8 +47,9 @@ func FuzzWithPort(f *testing.F) {
 	f.Add("65535")
 	f.Add("0")
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, port string) {
-		srv, err := server.New(server.WithPort(port))
+		srv, err := server.New(server.WithPort(port), server.WithLogger(logger))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -70,9 +72,10 @@ func FuzzWithHTTPServerTimeout(f *testing.F) {
 	f.Add(int64(1))
 	f.Add(int64(-1))
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, seconds int64) {
 		timeout := time.Duration(seconds) * time.Second
-		srv, err := server.New(server.WithHTTPServerTimeout(timeout))
+		srv, err := server.New(server.WithHTTPServerTimeout(timeout), server.WithLogger(logger))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -95,9 +98,10 @@ func FuzzWithHTTPServerShutdownTimeout(f *testing.F) {
 	f.Add(int64(1))
 	f.Add(int64(-1))
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, seconds int64) {
 		timeout := time.Duration(seconds) * time.Second
-		srv, err := server.New(server.WithHTTPServerShutdownTimeout(timeout))
+		srv, err := server.New(server.WithHTTPServerShutdownTimeout(timeout), server.WithLogger(logger))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -117,6 +121,7 @@ func FuzzNew(f *testing.F) {
 	f.Add("api", "3000", int64(30), int64(5))
 	f.Add("", "80", int64(0), int64(0))
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, name, port string, timeout, shutdownTimeout int64) {
 		timeoutDuration := time.Duration(timeout) * time.Second
 		shutdownTimeoutDuration := time.Duration(shutdownTimeout) * time.Second
@@ -126,6 +131,7 @@ func FuzzNew(f *testing.F) {
 			server.WithPort(port),
 			server.WithHTTPServerTimeout(timeoutDuration),
 			server.WithHTTPServerShutdownTimeout(shutdownTimeoutDuration),
+			server.WithLogger(logger),
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -155,10 +161,11 @@ func FuzzWithRouter(f *testing.F) {
 	// Add seed corpus
 	f.Add("")
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, _ string) {
 		// Create a new router for each iteration
 		router := http.NewServeMux()
-		srv, err := server.New(server.WithRouter(router))
+		srv, err := server.New(server.WithRouter(router), server.WithLogger(logger))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -200,13 +207,14 @@ func FuzzWithTLSConfig(f *testing.F) {
 	f.Add(uint16(tls.VersionTLS12))
 	f.Add(uint16(tls.VersionTLS13))
 
+	logger := log.New()
 	f.Fuzz(func(t *testing.T, minVersion uint16) {
 		// Create a basic TLS config (without loading certificates to avoid file I/O)
 		tlsConfig := &tls.Config{
 			MinVersion: minVersion,
 		}
 
-		srv, err := server.New(server.WithTLSConfig(tlsConfig))
+		srv, err := server.New(server.WithTLSConfig(tlsConfig), server.WithLogger(logger))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## Summary
This PR adds a logger instance to all fuzzing tests in `fuzz_test.go` to ensure the server is initialized with a valid logger, preventing potential nil pointer dereferences during fuzzing.

## Changes
- Created a `log.New()` logger instance in each fuzz test function before the fuzzing loop
- Updated all `server.New()` calls to include `server.WithLogger(logger)` option
- Applied consistently across 7 fuzz test functions:
  - `FuzzWithName`
  - `FuzzWithPort`
  - `FuzzWithHTTPServerTimeout`
  - `FuzzWithHTTPServerShutdownTimeout`
  - `FuzzNew`
  - `FuzzWithRouter`
  - `FuzzWithTLSConfig`

## Implementation Details
- The logger is instantiated once per fuzz test function (outside the fuzzing loop) for efficiency
- This ensures all server instances created during fuzzing have a valid logger configured
- The change maintains consistency across all fuzz tests and aligns with proper server initialization practices

https://claude.ai/code/session_01Utot9vFrX7PtTwkxGuzTox